### PR TITLE
allow to override 'type' for ESM support

### DIFF
--- a/packageCombine.js
+++ b/packageCombine.js
@@ -1,7 +1,7 @@
 "use strict";
 const fs = require('fs')
 
-//Prod location 
+//Prod location
 const path = "app/server/arena/package.json"; //'./server/room/package-json/package.json'
 
 fs.access(path, fs.F_OK, (err) => {
@@ -17,7 +17,7 @@ fs.access(path, fs.F_OK, (err) => {
         return;
 
     }
-  
+
     console.log("Found new package json to merge");
     var orgFile = fs.readFileSync('package.json');
     var newFile = fs.readFileSync(path);
@@ -37,7 +37,7 @@ fs.access(pathNPM, fs.F_OK, (err) => {
         // console.log("No .npmrc file found for deployment");
         return;
     }
-  
+
     console.log("Found custom .npmrc, using for npm install.");
     var npmrcFile = fs.readFileSync(pathNPM);
     fs.writeFileSync('.npmrc', npmrcFile);
@@ -80,6 +80,12 @@ function MergeFile(orgFile, newFile) {
 
         objOrg.dependencies = result;
 
+        //
+        // allow to override "type". use "commonjs" by default.
+        // https://nodejs.org/api/packages.html#packages_type
+        //
+        objOrg.type = objNew.type || "commonjs";
+
         // console.log("Merged results")
         // console.log(result);
 
@@ -98,6 +104,6 @@ function MergeFile(orgFile, newFile) {
         console.error("Failed to parse Package");
         console.error(error);
     }
-    
+
 
 }


### PR DESCRIPTION
I couldn't fully understand how Colyseus internal packages are being built for Arena.

This is what I've gathered, followed by a suggestion on how to fully support ESM:

- It seems that `tsc -d --project tsconfig-arena.json` is being used to build the packages into the `dist/` folder. 
- The `tsconfig-arena.json` file specifies the output to CommonJS (`"module": "commonjs"`)
- By compiling the sources **twice** we can support both CommonJS and ESM.

As you can see, [each package.json specifies two different entrypoints](https://github.com/Lucid-Sight-Inc/colyseus/blob/1cc243b63f3398d525c17260c3f013dd08b00451/packages/core/package.json#L6-L7):
- `main` (CommonJS entrypoint)
- `module` (ESM entrypoint)

```json
  "main": "./build/index.js",
  "module": "./build/index.mjs",
```

The `npm run build` script uses a tool (called Rollup) to compile the TypeScript files into both their `.js` and `.mjs` versions., inside each of the package's `build` folders. Each of these packages is meant to be published into NPM's registry.

---

## Possible workaround for Arena

As you're using the `dist/` folder, it can be possible to build **first** the ESM version of the packages, by having another `tsconfig-arena-esm.json` (using `"module": "ESNext"`)

```
tsc -d --project tsconfig-arena-esm.json
```

This is going to generate `.js` files, though. We can rename them to `.mjs` by using a renaming tool:

```
npm install --save-dev renamer
npx renamer --find '.js' --replace '.mjs' './dist/**/**/**/*.js'
```

After having the `.mjs` files we can then generate the `.js` for CommonJS as you're currently doing.

Let me know if you wanna discuss this further. Cheers!
