### PR TITLE
Upgrade uwebsockets-express 

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "prom-client": "^13.2.0",
     "redis": "^3.1.2",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v19.2.0",
-    "uwebsockets-express": "^1.1.13",
+    "uwebsockets-express": "^1.1.14",
     "winston": "^3.3.3"
   }
 }


### PR DESCRIPTION
Previous version was not capable of reaching HTTP middlewares bound to root path, which was the case of [`colyseus-examples`](https://github.com/colyseus/colyseus-examples/blob/9e653699026c45307ede3c66b911e0f383d49965/src/arena.config.ts#L63-L64):

```typescript
app.use('/', serveIndex(path.join(__dirname, "static"), {'icons': true}))
app.use('/', express.static(path.join(__dirname, "static")));
```
