### PR TITLE
remove unecessary decrementClientCount during disconnect()

### DIFF
--- a/packages/core/src/Room.ts
+++ b/packages/core/src/Room.ts
@@ -308,8 +308,6 @@ export abstract class Room<State= any, Metadata= any> {
     this.internalState = RoomInternalState.DISCONNECTING;
     await this.listing.remove();
 
-    StatsController.decrementClientCount(this.listing);
-
     this.autoDispose = true;
 
     const delayedDisconnection = new Promise<void>((resolve) =>


### PR DESCRIPTION
This call is potentially the reason of inaccurate CCU count. During `disconnect()` all clients are forcibly closed - which mean there will be a `this._decrementClientCount()` per client.