### PR TITLE
Log correct public endpoint 

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -292,7 +292,7 @@ async function SetupArenaPreListen() {
 }
 
 gameServer.listen(port)
-  .then(() => console.log(`Colyseus ${ APIVERSION }: Listening on ws://${endpoint}:${port}`))
+  .then(() => console.log(`Colyseus ${ APIVERSION }: Listening on wss://${endpoint}`))
   .catch((err) => {
     console.log(err);
     process.exit(1)


### PR DESCRIPTION
Users often unsuccessfully try to connect to either `ws://id.colyseus.dev:2567` or `wss://id.colyseus.dev:2567`. This log is potentially misguiding them to do so.