### PR TITLE
hincrby fix for Redis Presence

### DIFF
--- a/bundles/colyseus/test/PresenceTest.ts
+++ b/bundles/colyseus/test/PresenceTest.ts
@@ -197,19 +197,52 @@ describe("Presence", () => {
       it("incr", async () => {
         await presence.del("num"); //ensure key doens't exist before testing
 
-        await presence.incr("num");
-        await presence.incr("num");
-        await presence.incr("num");
+        var incr: number;
+
+        incr = await presence.incr("num");
+        assert.strictEqual(1, incr);
+
+        incr = await presence.incr("num");
+        assert.strictEqual(2, incr);
+
+        incr = await presence.incr("num");
+        assert.strictEqual(3, incr);
+
         assert.equal(3, await presence.get("num"));
       });
 
       it("decr", async () => {
         await presence.del("num"); //ensure key doens't exist before testing
 
-        await presence.decr("num");
-        await presence.decr("num");
-        await presence.decr("num");
+        var decr: number;
+
+        decr = await presence.decr("num");
+        assert.strictEqual(-1, decr);
+
+        decr = await presence.decr("num");
+        assert.strictEqual(-2, decr);
+
+        decr = await presence.decr("num");
+        assert.strictEqual(-3, decr);
+
         assert.equal(-3, await presence.get("num"));
+      });
+
+      it("hincrby", async () => {
+        await presence.del("hincrby"); //ensure key doens't exist before testing
+
+        var hincrby: number;
+
+        hincrby = await presence.hincrby("hincrby", "one", 1);
+        assert.strictEqual(1, hincrby);
+
+        hincrby = await presence.hincrby("hincrby", "one", 1);
+        assert.strictEqual(2, hincrby);
+
+        hincrby = await presence.hincrby("hincrby", "one", 1);
+        assert.strictEqual(3, hincrby);
+
+        assert.strictEqual('3', await presence.hget("hincrby", "one"));
       });
 
     });

--- a/bundles/colyseus/test/PresenceTest.ts
+++ b/bundles/colyseus/test/PresenceTest.ts
@@ -1,10 +1,11 @@
 import assert from "assert";
 import { timeout, PRESENCE_IMPLEMENTATIONS } from "./utils";
+import { Presence } from "@colyseus/core";
 
 describe("Presence", () => {
 
   for (let i = 0; i < PRESENCE_IMPLEMENTATIONS.length; i++) {
-    const presence = new PRESENCE_IMPLEMENTATIONS[i]();
+    const presence: Presence = new PRESENCE_IMPLEMENTATIONS[i]();
 
     describe((presence as any).constructor.name, () => {
 

--- a/packages/core/src/presence/LocalPresence.ts
+++ b/packages/core/src/presence/LocalPresence.ts
@@ -136,7 +136,9 @@ export class LocalPresence implements Presence {
     public hincrby(key: string, field: string, value: number) {
         if (!this.hash[key]) { this.hash[key] = {}; }
         const previousValue = Number(this.hash[key][field] || '0');
-        this.hash[key][field] = (previousValue + value).toString();
+        var incrby = (previousValue + value);
+        this.hash[key][field] = incrby.toString();
+        return incrby;
     }
 
     public async hget(key: string, field: string) {

--- a/packages/core/src/presence/LocalPresence.ts
+++ b/packages/core/src/presence/LocalPresence.ts
@@ -164,7 +164,7 @@ export class LocalPresence implements Presence {
             this.keys[key] = 0;
         }
         (this.keys[key] as number)++;
-        return this.keys[key];
+        return this.keys[key] as number;
     }
 
     public async decr(key: string) {
@@ -172,7 +172,7 @@ export class LocalPresence implements Presence {
             this.keys[key] = 0;
         }
         (this.keys[key] as number)--;
-        return this.keys[key];
+        return this.keys[key] as number;
     }
 
     public shutdown() {

--- a/packages/core/src/presence/Presence.ts
+++ b/packages/core/src/presence/Presence.ts
@@ -17,7 +17,7 @@ export interface Presence {
     sinter(...keys: string[]): Promise<string[]>;
 
     hset(key: string, field: string, value: string);
-    hincrby(key: string, field: string, value: number);
+    hincrby(key: string, field: string, value: number): number | Promise<number>;
     hget(key: string, field: string): Promise<string>;
     hgetall(key: string): Promise<{ [key: string]: string }>;
     hdel(key: string, field: string);

--- a/packages/presence/redis-presence/src/index.ts
+++ b/packages/presence/redis-presence/src/index.ts
@@ -22,7 +22,7 @@ export class RedisPresence implements Presence {
     protected pubsubAsync: any;
     protected incrAsync: any;
     protected decrAsync: any;
-    
+
     private prefix: string;
 
     constructor(opts?: redis.ClientOpts, prefix?: string) {
@@ -180,8 +180,11 @@ export class RedisPresence implements Presence {
 
     public async hincrby(key: string, field: string, value: number) {
         key = this.prefix+key;
-        return new Promise((resolve) => {
-            this.pub.hincrby(key, field, value, resolve);
+        return new Promise<number>((resolve, reject) => {
+          this.pub.hincrby(key, field, value, (err, result) => {
+            if (err) return reject(err);
+            resolve(result);
+          });
         });
     }
 


### PR DESCRIPTION
This fixes client's issue (https://lucidsight.slack.com/archives/C01S50ZU8SJ/p1661782430617389)

> We are having difficulty using Redis properly because the hincrby doesn't seem to be implemented properly.  This function is suppose to return a value, when used with redis, and that is what makes using redis as a semaphore possible. We don't have another way of keeping bots from entering multiple times with the same account without an atomic function, and all the atomic functionality of redis seems to be disabled.

> The hincrby is returning a promise, but it only returns null.  Whereas the redis documentation specifies that the value is initialized to 0 if it is not already set. However, even if it is preset to a value, the result is always null